### PR TITLE
Fixes #59, prune flags for ability delete remote content missing locally.

### DIFF
--- a/src/jottalib/cli.py
+++ b/src/jottalib/cli.py
@@ -285,6 +285,7 @@ def restore(argv=None):
 
 
 def scanner(argv=None):
+
     if argv is None:
         argv = sys.argv[1:]
 
@@ -301,19 +302,29 @@ def scanner(argv=None):
                         choices=('debug', 'info', 'warning', 'error'), default='warning')
     parser.add_argument('--errorfile', help='A file to write errors to', default='./jottacloudclient.log')
     parser.add_argument('--exclude', type=re.compile, action='append', help='Exclude paths matched by this pattern (can be repeated)')
+    parser.add_argument('--prune-files', dest='prune_files',
+                        help='Delete files that does not exist locally', action='store_true')
+    parser.add_argument('--prune-folders', dest='prune_folders',
+                        help='Delete folders that does not exist locally', action='store_true')
+    parser.add_argument('--prune-all', dest='prune_all',
+                        help='Combines --prune-files  and --prune-folders', action='store_true')
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('--dry-run', action='store_true',
                         help="don't actually do any uploads or deletes, just show what would be done")
     parser.add_argument('topdir', type=is_dir, help='Path to local dir that needs syncing')
     parser.add_argument('jottapath', help='The path at JottaCloud where the tree shall be synced (must exist)')
     args = parse_args_and_apply_logging_level(parser, argv)
+    if args.prune_all:
+        args.prune_files = True
+        args.prune_folders = True
+
     fh = logging.FileHandler(args.errorfile)
     fh.setLevel(logging.ERROR)
     logging.getLogger('').addHandler(fh)
 
     jfs = JFS.JFS()
 
-    filescanner(args.topdir, args.jottapath, jfs, args.errorfile, args.exclude, args.dry_run)
+    filescanner(args.topdir, args.jottapath, jfs, args.errorfile, args.exclude, args.dry_run, args.prune_files, args.prune_folders)
 
 
 def monitor(argv=None):

--- a/src/jottalib/scanner.py
+++ b/src/jottalib/scanner.py
@@ -78,7 +78,7 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False, 
                 _end = time.time()
                 puts(colored.magenta("Network upload speed %s/sec" % ( humanizeFileSize( (_uploadedbytes / (_end-_start)) ) )))
 
-            if len(onlyremote) and prune_files:
+            if prune_files and len(onlyremote):
                 puts(colored.red("Deleting %s files from JottaCloud because they no longer exist locally " % len(onlyremote)))
                 for f in progress.bar(onlyremote, label="deleting JottaCloud file: "):
                     log.debug("deleting cloud file that has disappeared locally: %s", f)
@@ -91,7 +91,7 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False, 
                     if not dry_run:
                         if saferun(jottacloud.replace_if_changed, f.localpath, f.jottapath, jfs) is not False:
                             _files += 1
-            if len(onlyremotefolders) and prune_folders:
+            if prune_folders and len(onlyremotefolders):
                 puts(colored.red("Deleting %s folders from JottaCloud because they no longer exist locally " % len(onlyremotefolders)))
                 for f in onlyremotefolders:
                     if not dry_run:

--- a/src/jottalib/scanner.py
+++ b/src/jottalib/scanner.py
@@ -45,7 +45,7 @@ def humanizeFileSize(size):
     p = math.floor(math.log(size, 2)/10)
     return "%.3f%s" % (size/math.pow(1024,p),units[int(p)])
 
-def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False):
+def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False, prune_files=True, prune_folders=True ):
 
     errors = {}
     def saferun(cmd, *args):
@@ -61,7 +61,7 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False):
     _files = 0
 
     try:
-        for dirpath, onlylocal, onlyremote, bothplaces in jottacloud.compare(topdir, jottapath, jfs, exclude_patterns=exclude):
+        for dirpath, onlylocal, onlyremote, bothplaces, onlyremotefolders in jottacloud.compare(topdir, jottapath, jfs, exclude_patterns=exclude):
             puts(colored.green("Entering dir: %s" % dirpath))
             if len(onlylocal):
                 _start = time.time()
@@ -78,7 +78,7 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False):
                 _end = time.time()
                 puts(colored.magenta("Network upload speed %s/sec" % ( humanizeFileSize( (_uploadedbytes / (_end-_start)) ) )))
 
-            if len(onlyremote):
+            if len(onlyremote) and prune_files:
                 puts(colored.red("Deleting %s files from JottaCloud because they no longer exist locally " % len(onlyremote)))
                 for f in progress.bar(onlyremote, label="deleting JottaCloud file: "):
                     log.debug("deleting cloud file that has disappeared locally: %s", f)
@@ -91,6 +91,12 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False):
                     if not dry_run:
                         if saferun(jottacloud.replace_if_changed, f.localpath, f.jottapath, jfs) is not False:
                             _files += 1
+            if len(onlyremotefolders) and prune_folders:
+                puts(colored.red("Deleting %s folders from JottaCloud because they no longer exist locally " % len(onlyremotefolders)))
+                for f in onlyremotefolders:
+                    if not args.dry_run:
+                        if saferun(jottacloud.deleteDir, f.jottapath, jfs) is not False:
+                            logging.debug("Deleted remote folder %s", f.jottapath)
     except KeyboardInterrupt:
         # Ctrl-c pressed, cleaning up
         pass
@@ -99,4 +105,3 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False):
     else:
         puts(('Finished syncing %s files, ' % _files )+
              colored.red('with %s errors (read %s for details)' % (len(errors), errorfile, )))
-

--- a/src/jottalib/scanner.py
+++ b/src/jottalib/scanner.py
@@ -94,7 +94,7 @@ def filescanner(topdir, jottapath, jfs, errorfile, exclude=None, dry_run=False, 
             if len(onlyremotefolders) and prune_folders:
                 puts(colored.red("Deleting %s folders from JottaCloud because they no longer exist locally " % len(onlyremotefolders)))
                 for f in onlyremotefolders:
-                    if not args.dry_run:
+                    if not dry_run:
                         if saferun(jottacloud.deleteDir, f.jottapath, jfs) is not False:
                             logging.debug("Deleted remote folder %s", f.jottapath)
     except KeyboardInterrupt:


### PR DESCRIPTION
Hi,
This introduces --prune-files, --prune-folders and --prune-all (for files and folders).
The old default behaviour was deleting files but not folders. Now the default is no deletion without the corresponding prune flag.