### PR TITLE
Fixed jottalib issue  #130.

### DIFF
--- a/src/jottalib/cli.py
+++ b/src/jottalib/cli.py
@@ -359,7 +359,7 @@ def download(argv=None):
 
             _abs_folder_path = posixpath.join(JFS.JFS_ROOT, folder[1:])
             logging.debug("absolute folder path  : %r", _abs_folder_path)
-            _rel_folder_path = _abs_folder_path[len(topdir)+1:]
+            _rel_folder_path = posixpath.join(*posixpath.join(folder.split("/")[4:]))
             logging.info('relative folder path: %r', _rel_folder_path)
 
             if len(_rel_folder_path) > 250: #Windows has a limit of 250 characters in path


### PR DESCRIPTION
Dirty, but works!
Using folder path and skips four slashes remove /username/Jotta/<Archive/Sync> to produce the _rel_folder_path
Not sure how to use it with the Backup directory, don't know how to test it.
